### PR TITLE
Join possessives and of's when chunking.

### DIFF
--- a/src/main/scala/org/allenai/ike/index/NlpAnnotate.scala
+++ b/src/main/scala/org/allenai/ike/index/NlpAnnotate.scala
@@ -16,7 +16,10 @@ object NlpAnnotate {
 
   def postag(tokens: Seq[Token]): Seq[PostaggedToken] = postagger.postagTokenized(tokens)
 
-  def chunk(tokens: Seq[PostaggedToken]): Seq[ChunkedToken] = chunker.chunkPostagged(tokens)
+  def chunk(tokens: Seq[PostaggedToken]): Seq[ChunkedToken] = {
+    val chunked = chunker.chunkPostagged(tokens)
+    Chunker.joinPos(Chunker.joinOf(chunked))
+  }
 
   def addEndingMarkers(tokens: Seq[ChunkedToken]): Seq[ChunkedToken] = {
     if (tokens.isEmpty) {


### PR DESCRIPTION
This should be a huge improvement to Ike's noun phrases.  Presently the noun phrases are cut off.

> John's bike is falling apart.

Before: "John", "bike" are separate noun phrases
After: "John's bike" is a noun phrase

> John lived in the state of Idaho

Before: "the state", "Idaho" are separate noun phrases
After" the state of Idaho" is a single noun phrase